### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ PR 제목 형식 (Conventional Commits):
 
 - [ ] 후방 호환성 영향 없음
 - [ ] 보안 영향 없음 (있다면 `security-review` 라벨 부착)
-- [ ] 다운스트림 11개 리포에 자동 동기화됨 (`scripts/deploy-to-repos.go` 변경 시)
+- [ ] 다운스트림 11개 리포에 자동 동기화됨 (`scripts/cmd/deploy-to-repos/main.go` 변경 시)
 
 ## Checklist
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -89,6 +89,18 @@ jobs:
           CONFIG.RESPONSE_LANGUAGE: ko
           CONFIG.AI_TIMEOUT: "180"
           CONFIG.CUSTOM_MODEL_MAX_TOKENS: "128000"
+          # Quality knobs — produce richer review output even on small diffs.
+          # See pr_agent/tools/pr_reviewer.py:85-94 for toggle->prompt mapping.
+          PR_REVIEWER.REQUIRE_SCORE_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_TESTS_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_ESTIMATE_EFFORT_TO_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_ESTIMATE_CONTRIBUTION_TIME_COST: "true"
+          PR_REVIEWER.REQUIRE_CAN_BE_SPLIT_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_SECURITY_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_TODO_SCAN: "true"
+          PR_REVIEWER.REQUIRE_TICKET_ANALYSIS_REVIEW: "true"
+          PR_REVIEWER.NUM_MAX_FINDINGS: "5"
+          PR_REVIEWER.PUBLISH_OUTPUT_NO_SUGGESTIONS: "false"
           GITHUB__USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NOTE: Dynaconf maps `GITHUB__USER_TOKEN` (double underscore) to the nested setting
           # `settings.github.user_token` because pr-agent's config_loader uses `envvar_prefix=False`
@@ -138,7 +150,10 @@ jobs:
             exit "$status"
           fi
 
-          if grep -E "BoxKeyError|GitHub token is required|Failed to get git provider|Failed to generate prediction with any model|Failed to review PR|AuthenticationError|Traceback" /tmp/pr-agent.log; then
+          # Silent-failure guard — pr_agent CLI returns exit 0 on most logical
+          # failures (caught Exception at pr_reviewer.py:184). Patterns below are
+          # confirmed in source (file:line in commit message).
+          if grep -E "Failed to generate prediction with any model|Failed to review PR|Rate limit error during LLM inference|Unknown error during LLM inference|Error during LLM inference|Failed to publish (code suggestion|inline code comments fallback|diffview file summary|labels)|Cannot publish a comment if missing PR|Failed to get (diff files|merge base commit)|Failed to add AI metadata|Empty prediction|ai handler not set|Unable to decode JSON response|Failed to parse AI prediction|Rate limit exceeded for git provider|BoxKeyError|GitHub token is required|Failed to get git provider|AuthenticationError" /tmp/pr-agent.log | grep -vE "(Empty diff for PR:|PR has no files:|Incremental review is enabled.*but there are no new (files|commits)|Review output is not published|Incremental review is not supported)"; then
             echo "::error::pr-agent reported a fatal error but exited 0 (silent failure)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.
