### PR TITLE
ci: standardize GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: jclee941/.github/.github/workflows/reusable-ci.yml@master
+    secrets: inherit


### PR DESCRIPTION
Standardize GitHub Actions to use `jclee941/.github` reusable workflows.

- `ci.yml` (or `standard-ci.yml` if existing ci.yml is preserved): calls `reusable-ci.yml` (lint + test + build with language autodetect: Node/Python/Go/Terraform)
- `pr-checks.yml`: calls `reusable-pr-checks.yml` (PR title/branch/size/description checks)

Generated by repo standardization sweep.