### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,10 +32,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download actionlint
-        id: get_actionlint
         run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
 
       - name: Run actionlint
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: ./actionlint -color
         shell: bash

--- a/.github/workflows/branch-to-pr.yml
+++ b/.github/workflows/branch-to-pr.yml
@@ -1,9 +1,9 @@
-name: Branch to Draft PR
+name: Branch to PR
 
 # When a feat/* fix/* hotfix/* docs/* refactor/* perf/* test/* chore/*
 # ci/* security/* build/* style/* revert/* branch is pushed and no
-# open PR exists targeting the default branch, open a draft PR.
-# Skip if author is jclee-bot itself (avoids recursion).
+# open PR exists targeting the default branch, open a ready-for-review PR
+# with auto-merge label. Skip if author is jclee-bot itself.
 
 on:
   push:
@@ -48,7 +48,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  open-draft-pr:
+  open-ready-pr:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Skip pushes from jclee-bot itself or from automated branch creation.
@@ -105,7 +105,7 @@ jobs:
         run: |
           set -eu
           # Build PR body.
-          BODY="## 변경사항"$'\n\n'"<!-- 자동으로 생성된 draft PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->"$'\n\n'
+          BODY="## 변경사항"$'\n\n'"<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->"$'\n\n'
           if [ -n "$ISSUE_NUM" ]; then
             BODY="${BODY}Closes #${ISSUE_NUM}"$'\n\n'
           fi
@@ -119,15 +119,15 @@ jobs:
           BODY="${BODY}$(cat /tmp/commits.txt)"
           BODY="${BODY}"$'\n\n'"> Automated by jclee-bot (branch-to-pr.yml)"
           if [ "$DRY_RUN" = "true" ]; then
-            echo "::notice::DRY-RUN: would open draft PR $BRANCH -> $BASE"
+          echo "::notice::DRY-RUN: would open ready PR $BRANCH -> $BASE"
             echo "title: $TITLE"
             echo "body: $BODY"
             exit 0
           fi
-          # Create the draft PR.
+          # Create the PR.
           gh pr create --repo "$GITHUB_REPOSITORY" \
             --head "$BRANCH" --base "$BASE" \
             --title "$TITLE" \
             --body "$BODY" \
-            --draft \
+            --label "auto-merge" \
             || echo "::warning::PR creation failed (likely already exists or no diff yet)"

--- a/.github/workflows/issue-to-branch.yml
+++ b/.github/workflows/issue-to-branch.yml
@@ -7,7 +7,7 @@ name: Issue to Branch
 
 on:
   issues:
-    types: [labeled, assigned]
+    types: [opened, labeled, assigned]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -35,6 +35,7 @@ jobs:
     # Trigger only when the label is `in-progress` OR the issue gets assigned to a human (not the bot itself).
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'opened') ||
       (github.event.action == 'labeled' && github.event.label.name == 'in-progress') ||
       (github.event.action == 'assigned' && github.event.assignee.login != 'jclee-bot')
     steps:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -85,7 +85,7 @@ jobs:
           OPENAI.KEY: ${{ secrets.CLIPROXY_API_KEY }}
           OPENAI.API_BASE: https://cliproxy.jclee.me/v1
           CONFIG.MODEL: kimi-k2.6
-          CONFIG.FALLBACK_MODELS: '["kimi-k2.5", "claude-sonnet-4-6"]'
+          CONFIG.FALLBACK_MODELS: '["kimi-k2.5", "minimax-m2.7"]'
           CONFIG.RESPONSE_LANGUAGE: ko
           CONFIG.AI_TIMEOUT: "180"
           CONFIG.CUSTOM_MODEL_MAX_TOKENS: "128000"

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -29,6 +29,12 @@ jobs:
             || { echo "::warning::gh pr view failed (likely rate limit); skipping size check"; exit 0; }
           echo "PR #$PR_NUM (author=$AUTHOR) total changed lines: $LOC_DATA"
           if [ "$LOC_DATA" -gt 500 ]; then
+            # Dedup: if an open issue already exists for this PR, skip creating a new one.
+            EXISTING=$(gh issue list --repo "$REPO" --state open --search "\"PR #$PR_NUM exceeds 500 LOC\" in:title" --json number -q '.[0].number' 2>/dev/null || true)
+            if [ -n "$EXISTING" ]; then
+              echo "::notice::Oversized-PR issue already exists (#$EXISTING); skipping create"
+              exit 0
+            fi
             gh issue create --repo "$REPO" \
               --title "[BOT] PR #$PR_NUM exceeds 500 LOC ($LOC_DATA lines)" \
               --body "## Large PR Detected\n\n- **PR**: #$PR_NUM\n- **Changed Lines**: $LOC_DATA\n- **Threshold**: 500\n\nThis PR exceeds the recommended maximum of 500 changed lines. Consider splitting it into smaller, focused PRs for easier review.\n\n> Automated by jclee-bot" \

--- a/.github/workflows/security/pr-review.yml
+++ b/.github/workflows/security/pr-review.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Check out base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-sec-${{ hashFiles('pyproject.toml', 'requirements.txt') }}


### PR DESCRIPTION
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.
