### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/branch-to-pr.yml
+++ b/.github/workflows/branch-to-pr.yml
@@ -67,13 +67,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_BASE: ${{ inputs.base }}
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
           set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BRANCH="${{ inputs.branch }}"
-            BASE="${{ inputs.base }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BRANCH="$INPUT_BRANCH"
+            BASE="$INPUT_BASE"
           else
             BRANCH="${GITHUB_REF#refs/heads/}"
-            BASE="${{ github.event.repository.default_branch }}"
+            BASE="$DEFAULT_BRANCH"
           fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -100,9 +100,13 @@ jobs:
           if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             PR_NUMBER="0"
           fi
-          if [[ "$CONCLUSION" != "success" && "$CONCLUSION" != "failure" ]]; then
-            echo "::error::Invalid conclusion: $CONCLUSION (must be success or failure)"
+          if [[ "$CONCLUSION" != "success" && "$CONCLUSION" != "failure" && "$CONCLUSION" != "cancelled" && "$CONCLUSION" != "skipped" ]]; then
+            echo "::error::Invalid conclusion: $CONCLUSION (must be success, failure, cancelled, or skipped)"
             exit 1
+          fi
+          # For cancelled/skipped, treat as failure for issue creation purposes
+          if [[ "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "skipped" ]]; then
+            CONCLUSION="failure"
           fi
 
           {

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ${{ github.event.repository.private && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-    steps:
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v3


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (kimi-k2.6 → minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `branch-to-pr` 환경변수 기반 스크립트 인젝션 방지

- `ci-failure-issues`에서 `cancelled`와 `skipped`를 실패로 처리

- `dependabot-auto-merge`의 중복 `steps` 키 제거


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["branch-to-pr.yml"] -- "환경변수 추출" --> B["스크립트 인젝션 방지"]
  C["ci-failure-issues.yml"] -- "cancelled/skipped 처리" --> D["상태 로직 개선"]
  E["dependabot-auto-merge.yml"] -- "중복 steps 제거" --> F["YAML 구조 수정"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>branch-to-pr.yml`</strong><dd><code>스크립트 인젝션 방지를 위한 환경변수 분리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/branch-to-pr.yml`

<ul><li><code>${{ }}</code> 표현식을 직접 셸 스크립트에서 사용하던 방식을 제거<br> <li> <code>INPUT_BRANCH</code>, <code>INPUT_BASE</code>, <code>EVENT_NAME</code>, <code>DEFAULT_BRANCH</code> 환경변수 추가<br> <li> 환경변수를 통해 셸 실행 시 스크립트 인젝션 취약점 방지</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-failure-issues.yml`</strong><dd><code>CI 결론값 검증 범위 확대 및 상태 매핑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/ci-failure-issues.yml`

<ul><li><code>cancelled</code>와 <code>skipped</code>를 유효한 <code>CONCLUSION</code> 값으로 추가 허용<br> <li> 취소 및 건너뛰기 상태를 이슈 생성을 위해 <code>failure</code>로 매핑<br> <li> 검증 실패 메시지의 허용 상태값 목록을 확장</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml`</strong><dd><code>잘못된 YAML 구조의 중복 steps 키 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/dependabot-auto-merge.yml`

- 중복으로 선언된 `steps` 키 중 하나를 제거
- 워크플로우 YAML 구조 오류 수정


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

