### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/21_docs-sync.yml
+++ b/.github/workflows/21_docs-sync.yml
@@ -24,4 +24,6 @@ jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     uses: jclee941/.github/.github/workflows/42_reusable-docs-sync.yml@master
+    with:
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -1,6 +1,16 @@
 name: Reusable Documentation Sync
 on:
   workflow_call:
+    inputs:
+      is_pull_request:
+        description: >-
+          Whether the calling workflow was triggered by a pull_request event.
+          Reusable workflows run with github.event_name == 'workflow_call',
+          so the caller must forward its own event via this input; otherwise
+          PR-only jobs would silently skip in downstream repos.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -14,7 +24,7 @@ concurrency:
 
 jobs:
   link-check:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -61,8 +71,55 @@ jobs:
               labels: ['documentation', 'bot', 'broken-links']
             });
 
+  private-ip-check:
+    # Detect hardcoded RFC 1918 private IPs in Markdown docs. Runs against
+    # downstream repos too: they call this reusable workflow via the central
+    # `@master` reference, so edits here propagate without re-deploy. The
+    # detector script is pulled from jclee941/.github so downstream repos need
+    # not vendor it.
+    if: ${{ inputs.is_pull_request }}
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Checkout detector script (from jclee941/.github)
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          path: tooling
+          sparse-checkout: |
+            scripts/check_private_ips.py
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Scan Markdown for hardcoded private IPs
+        run: |
+          set -eu
+          python tooling/scripts/check_private_ips.py pr \
+            2> ip-report.txt || EXIT=$?
+          cat ip-report.txt || true
+          if [ "${EXIT:-0}" -ne 0 ]; then
+            echo "::error::Hardcoded private IP(s) found in Markdown docs. See log above."
+            exit 1
+          fi
+
+
   markdown-lint:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -97,7 +154,7 @@ jobs:
   readme-sync-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
@@ -158,7 +215,7 @@ jobs:
   api-docs-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 재사용 문서 워크플로 입력 추가

- PR 전용 검사 실행 조건 수정

- Markdown 사설 IP 검사 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  caller["호출 워크플로"] -- "PR 여부 전달" --> reusable["재사용 문서 워크플로"]
  reusable -- "조건 평가" --> prchecks["PR 전용 문서 검사"]
  prchecks -- "추가 검사" --> privateip["Markdown 사설 IP 탐지"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>21_docs-sync.yml</strong><dd><code>문서 동기화 호출에 PR 여부 전달</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/21_docs-sync.yml

<ul><li>재사용 문서 동기화 워크플로 호출 시 <code>is_pull_request</code> 입력을 전달합니다.<br> <li> 호출 원본 이벤트가 <code>pull_request</code>인지 여부를 하위 워크플로에서 알 수 있게 합니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/155/files#diff-3d3f5ca189d8f130eef4fa86fa234e14aa1670211d5abbd6b63e848a1fb3234c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml</strong><dd><code>재사용 문서 워크플로 PR 검사 보강</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/42_reusable-docs-sync.yml

<ul><li><code>workflow_call</code>에 boolean 입력 <code>is_pull_request</code>를 추가합니다.<br> <li> <code>workflow_call</code> 이벤트에서도 PR 전용 작업이 실행되도록 조건을 <code>inputs.is_pull_request</code>로 <br>변경합니다.<br> <li> Markdown 문서의 RFC 1918 사설 IP 하드코딩을 탐지하는 <code>private-ip-check</code> 작업을 추가합니다.<br> <li> 검사 스크립트는 <code>jclee941/.github</code> 저장소에서 sparse checkout으로 가져와 실행합니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/155/files#diff-64d7718cef016c48a850cd68a87492080f9f003163a2f08dca31ca9a1505946b">+61/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

