### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/25_release-publish.yml
+++ b/.github/workflows/25_release-publish.yml
@@ -100,7 +100,10 @@ jobs:
       - name: Create tag
         if: steps.bump.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_PAT (falls back to GITHUB_TOKEN) so the created tag push
+          # triggers tag-listening workflows (24_release-notes.yml on push.tags:v*).
+          # GITHUB_TOKEN-created events do NOT trigger other workflows (recursion guard).
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
           SHA: ${{ steps.bump.outputs.sha }}
           BUMP: ${{ steps.bump.outputs.bump }}


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- 태그 생성 시 GH_PAT 우선 사용

- 후속 워크플로우 트리거 문제 해결

- GITHUB_TOKEN 폴백 메커니즘 유지


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["25_release-publish.yml<br/>Create tag"] -- "GITHUB_TOKEN" --> B["후속 워크플로우<br/>미트리거"]
    A -- "GH_PAT || GITHUB_TOKEN" --> C["24_release-notes.yml<br/>트리거"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>25_release-publish.yml</strong><dd><code>태그 생성 토큰을 GH_PAT로 변경하여 후속 워크플로우 트리거 활성화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/25_release-publish.yml

<ul><li><code>Create tag</code> 단계의 <code>GH_TOKEN</code> 환경변수를 <code>${{ secrets.GITHUB_TOKEN }}</code>에서 <code>${{ </code><br><code>secrets.GH_PAT || secrets.GITHUB_TOKEN }}</code>으로 변경<br> <li> <code>GITHUB_TOKEN</code>으로 생성된 이벤트가 다른 워크플로우를 트리거하지 못하는 GitHub Actions 제한을 우회<br> <li> 태그 푸시 시 <code>24_release-notes.yml</code>과 같은 후속 워크플로우가 정상 실행되도록 수정<br> <li> <code>GH_PAT</code>이 설정되지 않은 경우 <code>GITHUB_TOKEN</code>으로 폴백하여 하위호환성 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/178/files#diff-75b50e1ce761fb180776ec5f2d24e711f991d1f2e9c661d2fd8d86dd461b9ad8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

