### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/06_codeql.yml
+++ b/.github/workflows/06_codeql.yml
@@ -16,8 +16,6 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
-  schedule:
-    - cron: '23 4 * * 1'  # Mondays 04:23 UTC (off-peak)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/08_scorecard.yml
+++ b/.github/workflows/08_scorecard.yml
@@ -1,8 +1,6 @@
 name: Scorecard supply-chain security
 on:
   branch_protection_rule:
-  schedule:
-    - cron: '0 9 * * 1'
   push:
     branches: [master, main]
   workflow_dispatch:

--- a/.github/workflows/18_issue-management.yml
+++ b/.github/workflows/18_issue-management.yml
@@ -1,7 +1,5 @@
 name: Issue Management
 on:
-  schedule:
-    - cron: '0 0 * * *'
   issues:
     types: [opened, edited, closed, reopened, labeled, unlabeled, assigned]
   issue_comment:

--- a/.github/workflows/19_issue-backfill.yml
+++ b/.github/workflows/19_issue-backfill.yml
@@ -17,9 +17,6 @@ name: Issue Backfill
 # actually mutates labels.
 
 on:
-  schedule:
-    # Daily 09:00 UTC (18:00 KST). Manual dispatch is the primary path.
-    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -4,8 +4,6 @@ on:
   # Manual trigger
   workflow_dispatch:
   # Weekly auto-generation (Sundays 00:00 UTC)
-  schedule:
-    - cron: '0 0 * * 0'
   # Trigger when source/config files change on master
   push:
     branches: [master, main]

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -5,9 +5,6 @@ name: Downstream Health Check
 # Closes the issue when all repos are green.
 
 on:
-  schedule:
-    # 09:05 KST daily (00:05 UTC) - offset by 5min to avoid collision with 18_issue-management
-    - cron: '5 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -24,10 +24,6 @@ on:
       - "CI Auto-Heal"
       - "Repository Health Check"
     types: [completed]
-  schedule:
-    # Daily stale-failure-issue sweep: close failure/health issues whose
-    # originating workflow has since recovered (latest master run == success).
-    - cron: "45 5 * * *"  # 05:45 UTC daily (offset from other crons)
   workflow_dispatch:
     inputs:
       workflow_name:
@@ -342,7 +338,7 @@ jobs:
   # This is the safety-net layer for issues the event-driven path missed
   # (missed webhooks, renamed workflows, legacy per-run-id-titled issues).
   sweep:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/43_reusable-issue-management.yml
+++ b/.github/workflows/43_reusable-issue-management.yml
@@ -149,7 +149,7 @@ jobs:
   issue-stats:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -1,7 +1,5 @@
 name: CI Auto-Heal
 on:
-  schedule:
-    - cron: '0 3 * * *'  # Daily 03:00 UTC
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/91_issue-classification.yml
+++ b/.github/workflows/91_issue-classification.yml
@@ -25,8 +25,6 @@ on:
     types: [created]
   pull_request:
     types: [closed]
-  schedule:
-    - cron: '30 1 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -554,8 +552,8 @@ jobs:
         uses: ./.github/actions/notify-on-failure
 
   resolved-sweep:
-    name: Scheduled resolved sweep
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Manual resolved sweep
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 10개 워크플로우에서 `cron` 예약 트리거 제거

- `workflow_dispatch` 및 이벤트 기반 실행으로 전환

- 예약 실행 관련 `if` 조건 및 잡 이름 수정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cron["예약된 Cron 트리거"] -- "10개 워크플로우에서 제거" --> trigger["이벤트 및 수동 트리거"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>06_codeql.yml</strong><dd><code>CodeQL 워크플로우 주간 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-8096e35558e697079751a0ea2cef1d7e35451b01b96acc71112501756fed1d37">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>08_scorecard.yml</strong><dd><code>Scorecard 워크플로우 주간 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-3f8dd3c926ebcb070a478236f27005874644e69d024ddec128f338b9b07fb914">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>18_issue-management.yml</strong><dd><code>Issue Management 워크플로우 일일 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-3caeb48705f796f99cff063e7b2f8f0e19ecdfeca170f95e8c8122871bf615f2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>19_issue-backfill.yml</strong><dd><code>Issue Backfill 워크플로우 일일 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-914e840b0cc93b17a66743ce19039a60377cd51fd51d85800fdb6edf4072393d">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>20_readme-gen.yml</strong><dd><code>README 생성 워크플로우 주간 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>29_downstream-health-check.yml</strong><dd><code>하위 저장소 헬스체크 워크플로우 일일 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 워크플로우 `cron` 제거 및 sweep 조건 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>43_reusable-issue-management.yml</strong><dd><code>재사용 이슈 관리 워크플로우 `issue-stats` 조건 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-57075a88baa77fc4d46f1579e284e6a9fc7b70634cfd3520edb0da93f9f6b5ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>60_ci-auto-heal.yml</strong><dd><code>CI Auto-Heal 워크플로우 일일 `cron` 스케줄 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>91_issue-classification.yml</strong><dd><code>이슈 분류 워크플로우 `cron` 제거 및 `resolved-sweep` 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/182/files#diff-925a942cf5a654079bece14ac3b1117622177ca4276c6bdc6cde64a0f9e34954">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

