### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-python-compatible/action.yml
+++ b/.github/actions/setup-python-compatible/action.yml
@@ -36,7 +36,7 @@ runs:
         PY_VERSION="${{ inputs.python-version }}"
         VENV_DIR="${RUNNER_TEMP:-/tmp}/setup-python-compatible-${PY_VERSION}"
         uv python install "${PY_VERSION}"
-        uv venv --python "${PY_VERSION}" "${VENV_DIR}"
+        uv venv --seed --python "${PY_VERSION}" "${VENV_DIR}"
         echo "${VENV_DIR}/bin" >> "${GITHUB_PATH}"
         echo "VIRTUAL_ENV=${VENV_DIR}" >> "${GITHUB_ENV}"
         "${VENV_DIR}/bin/python" --version

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -47,6 +47,11 @@ jobs:
           repository: jclee941/.github
           path: .github-inventory
 
+      - name: Set up Python 3.12
+        uses: ./.github/actions/setup-python-compatible
+        with:
+          python-version: '3.12'
+
       - name: Check latest workflow runs across all repos
         id: health
         env:
@@ -54,7 +59,11 @@ jobs:
         run: |
           set -u
 
-          REPOS=$(ruby -ryaml -e 'puts YAML.load_file(".github-inventory/config/repos.yaml").fetch("repositories").select { |repo| repo.fetch("automation").fetch("health_check") }.map { |repo| repo.fetch("name") }.join(" ")')
+          # Parse the inventory with python3 (always present) instead of ruby,
+          # which is not installed on the self-hosted Debian runner. PyYAML is
+          # installed on demand so this works regardless of the base image.
+          python3 -c 'import yaml' 2>/dev/null || pip install --quiet pyyaml
+          REPOS=$(python3 -c 'import yaml; d=yaml.safe_load(open(".github-inventory/config/repos.yaml")); print(" ".join(r["name"] for r in d["repositories"] if r.get("automation",{}).get("health_check")))')
           WORKFLOWS=("actionlint" "pr-checks" "gitleaks")
           FAILURES=()
 

--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -113,6 +113,13 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout local actions (workspace root)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Checkout PR
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -31,6 +31,12 @@ jobs:
           terraform version 2>/dev/null || echo "terraform not available"
           node --version
           go version 2>/dev/null || echo "go not available"
+      - name: Checkout local actions (workspace root)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
       - name: Checkout decision helper
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- `uv venv`에 `--seed` 플래그를 추가하여 가상 환경 생성 시 pip/wheel 포함 보장

- 로컬 GitHub Actions를 사용하는 워크플로우에 `.github/actions` 체크아웃 스텝 추가

- Ruby에서 Python으로 YAML 파싱 방식으로 변경하여 self-hosted Debian 러너 호환성 개선

- self-hosted 러너에서 PyYAML 미설치 시 자동 설치 fallback 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[setup-python-compatible action] -->|uv venv --seed 추가| B[가상 환경에 pip 포함]
  C[downstream-health-check 워크플로우] -->|Ruby → Python 변경| D[self-hosted 호환]
  E[docs-sync 워크플로우] -->|로컬 액션 체크아웃 추가| F[setup-python-compatible 사용 가능]
  G[ci-auto-heal 워크플로우] -->|로컬 액션 체크아웃 추가| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>uv venv에 seed 플래그 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-python-compatible/action.yml

<ul><li><code>uv venv</code> 명령에 <code>--seed</code> 플래그를 추가하여 가상 환경 생성 시 pip과 wheel을 포함시킴<br> <li> 이로써 생성된 가상 환경에서 pip을 즉시 사용할 수 있음</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/242/files#diff-bbfbf888db87464ae833f321d5f66492058f163a2e8902e3d10f6558fab54c81">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>Ruby에서 Python으로 변경 및 로컬 액션 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li>Python 3.12 설정을 위한 로컬 액션 체크아웃 스텝 추가<br> <li> Ruby 기반 YAML 파싱을 Python으로 대체 (self-hosted Debian 러너에 Ruby 미설치 대응)<br> <li> PyYAML 미설치 시 <code>pip install --quiet pyyaml</code>으로 자동 설치</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/242/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml</strong><dd><code>로컬 액션 체크아웃 스텝 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/42_reusable-docs-sync.yml

<ul><li>sparse-checkout를 사용하여 <code>.github/actions</code> 디렉토리만 체크아웃하는 스텝 추가<br> <li> 이후 스텝에서 로컬 <code>setup-python-compatible</code> 액션 사용 가능해짐</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/242/files#diff-64d7718cef016c48a850cd68a87492080f9f003163a2f08dca31ca9a1505946b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>로컬 액션 체크아웃 스텝 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li>sparse-checkout를 사용하여 <code>.github/actions</code> 디렉토리만 체크아웃하는 스텝 추가<br> <li> 이후 스텝에서 로컬 <code>setup-python-compatible</code> 액션 사용 가능해짐</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/242/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

