### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -1,0 +1,69 @@
+name: Set up build cache
+description: >-
+  Route build caches (Go, pip, uv, npm, Docker buildx) to the NFS-backed mount
+  (/mnt/nas-cache) on self-hosted runners, and give HOME a stable LOCAL path.
+  The self-hosted LXC runner has HOME unset and a small 32G rootfs, so build
+  caches were ephemeral and disk-pressuring. Caches go to NAS; HOME stays local
+  (RUNNER_TEMP) to avoid persisting credentials/git/ssh state and NFS locking.
+  On GitHub-hosted runners this is a no-op (existing actions/cache flow is kept).
+
+runs:
+  using: composite
+  steps:
+    - name: Configure NAS-backed build cache (self-hosted only)
+      if: runner.environment == 'self-hosted'
+      shell: bash
+      run: |
+        set -eu
+
+        slug() {
+          printf '%s' "$1" | tr '/:@ ' '____' | tr -cd 'A-Za-z0-9._-'
+        }
+        runner_slug="$(slug "${RUNNER_NAME:-self-hosted}")"
+        repo_slug="$(slug "${GITHUB_REPOSITORY:-unknown-repo}")"
+
+        nas_base="/mnt/nas-cache"
+        local_base="${RUNNER_TEMP:-/tmp}/gha-cache"
+
+        # Prefer the NAS mount; degrade to a local path if it is missing or
+        # not writable so a broken mount never hard-fails the build.
+        if [ -d "$nas_base" ] && [ -w "$nas_base" ]; then
+          base="$nas_base"
+          echo "build cache: using NAS mount $nas_base"
+        else
+          base="$local_base"
+          echo "::warning::NAS mount $nas_base unavailable/unwritable; falling back to $local_base"
+        fi
+
+        cache_root="$base/$runner_slug/$repo_slug"
+        # HOME stays LOCAL (never on NAS) to avoid persisting secrets/git/ssh
+        # state and NFS lock contention. This also fixes the unset-HOME bug.
+        home_dir="${RUNNER_TEMP:-/tmp}/gha-home"
+
+        mkdir -p \
+          "$home_dir" \
+          "$cache_root/go-build" \
+          "$cache_root/go-mod" \
+          "$cache_root/pip" \
+          "$cache_root/uv" \
+          "$cache_root/npm" \
+          "$cache_root/xdg" \
+          "$cache_root/tmp" \
+          "$cache_root/docker-buildx" \
+          "$cache_root/docker-buildx-new"
+
+        {
+          echo "HOME=$home_dir"
+          echo "CACHE_ROOT=$cache_root"
+          echo "GOCACHE=$cache_root/go-build"
+          echo "GOMODCACHE=$cache_root/go-mod"
+          echo "PIP_CACHE_DIR=$cache_root/pip"
+          echo "UV_CACHE_DIR=$cache_root/uv"
+          echo "npm_config_cache=$cache_root/npm"
+          echo "XDG_CACHE_HOME=$cache_root/xdg"
+          echo "TMPDIR=$cache_root/tmp"
+          echo "DOCKER_BUILDX_CACHE=$cache_root/docker-buildx"
+          echo "DOCKER_BUILDX_CACHE_NEW=$cache_root/docker-buildx-new"
+        } >> "$GITHUB_ENV"
+
+        echo "build cache root: $cache_root (HOME=$home_dir)"

--- a/.github/workflows/10_pr-review.yml
+++ b/.github/workflows/10_pr-review.yml
@@ -52,6 +52,9 @@ jobs:
           path: pr-agent-src
           fetch-depth: 1
 
+      - name: Set up build cache (NAS-backed on self-hosted)
+        uses: ./.github/actions/setup-build-cache
+
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-compatible
         with:
@@ -60,7 +63,7 @@ jobs:
       - name: Cache pip dependencies
         uses: actions/cache@v5
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR || '~/.cache/pip' }}
           key: ${{ runner.os }}-pr-review-${{ hashFiles('pr-agent-src/pyproject.toml', 'pr-agent-src/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pr-review-

--- a/.github/workflows/11_security-pr-review.yml
+++ b/.github/workflows/11_security-pr-review.yml
@@ -41,6 +41,9 @@ jobs:
           path: pr-agent-src
           fetch-depth: 1
 
+      - name: Set up build cache (NAS-backed on self-hosted)
+        uses: ./.github/actions/setup-build-cache
+
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-compatible
         with:
@@ -49,7 +52,7 @@ jobs:
       - name: Cache pip dependencies
         uses: actions/cache@v5
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR || '~/.cache/pip' }}
           key: ${{ runner.os }}-pip-sec-${{ hashFiles('pr-agent-src/pyproject.toml', 'pr-agent-src/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-sec-

--- a/.github/workflows/14_bot-auto-fix.yml
+++ b/.github/workflows/14_bot-auto-fix.yml
@@ -40,6 +40,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
+      - name: Set up build cache (NAS-backed on self-hosted)
+        uses: ./.github/actions/setup-build-cache
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -52,11 +55,11 @@ jobs:
       - name: Run naming validator with --fix
         id: fix
         env:
-          # The self-hosted runner has HOME unset, so `go env` fails with
-          # "GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are
-          # defined". Provide cache dirs explicitly.
-          GOCACHE: ${{ runner.temp }}/go-build
-          GOMODCACHE: ${{ runner.temp }}/go-mod
+          # GOCACHE/GOMODCACHE come from setup-build-cache (NAS-backed on
+          # self-hosted, local fallback otherwise). Keep an explicit fallback
+          # to runner.temp in case the cache step was skipped.
+          GOCACHE: ${{ env.GOCACHE || format('{0}/go-build', runner.temp) }}
+          GOMODCACHE: ${{ env.GOMODCACHE || format('{0}/go-mod', runner.temp) }}
         run: |
           set -eu
           echo "Running validate-naming --fix..."


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- 새 composite action `.github/actions/setup-build-cache/action.yml` 추가: 자체 호스팅_runner의 NFS 마운트에 빌드 캐시 저장 (32G rootfs 디스크 부족 문제 해결)

- `10_pr-review.yml`, `11_security-pr-review.yml`, `14_bot-auto-fix.yml` 워크플로우에서 새 build-cache action 사용

- pip 캐시 경로를 하드코딩 `~/.cache/pip`에서 `${{ env.PIP_CACHE_DIR || '~/.cache/pip' }}`로 변경하여 동적 경로 활용

- Go 캐시 환경변수(GOCACHE, GOMODCACHE)를 setup-build-cache 출력값 사용으로 통합


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[setup-build-cache action] --> B[NAS mount /mnt/nas-cache]
  A --> C[Local fallback /tmp/gha-cache]
  B --> D[Workflows: PR review, Security review, Bot auto-fix]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>NAS 백업 빌드 캐시 설정 composite action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-build-cache/action.yml

<ul><li>자체 호스팅 runner용 composite action 신규 생성<br> <li> NFS 마운트(/mnt/nas-cache)에 Go, pip, uv, npm, Docker buildx 캐시 저장<br> <li> HOME은 항상 로컬(RUNNER_TEMP)으로 유지하여 NFS 잠금 경합 및 자격 증명 유출 방지<br> <li> 마운트 불가 시 로컬 임시 디렉토리로 자동 폴백<br> <li> 환경변수(GOCACHE, PIP_CACHE_DIR 등) GITHUB_ENV에 출력</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/257/files#diff-e22dec1852d6dcbcb4a828b3ac0538fa7b31fc4cc637f5828e2111e763fba58c">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>10_pr-review.yml</strong><dd><code>PR review 워크플로우에 build-cache action 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/10_pr-review.yml

<ul><li>새 <code>setup-build-cache</code> action 통합 (self-hosted runner에서 NAS 캐시 사용)<br> <li> pip 캐시 경로를 <code>${{ env.PIP_CACHE_DIR || '~/.cache/pip' }}</code>로 변경하여 동적 활용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/257/files#diff-e0248294e18c71b65ec8bd370fad557a9d6126473c7baca6a3df2dd574136be1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>11_security-pr-review.yml</strong><dd><code>Security PR review 워크플로우에 build-cache action 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/11_security-pr-review.yml

- 새 `setup-build-cache` action 통합
- pip 캐시 경로를 동적 환경변수 사용으로 변경


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/257/files#diff-66b389e0e0e0f862bb026a47a3791eda0aeec80105ac5155d6b6a77268777427">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>14_bot-auto-fix.yml</strong><dd><code>Bot auto-fix 워크플로우에 build-cache action 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/14_bot-auto-fix.yml

<ul><li>새 <code>setup-build-cache</code> action 통합<br> <li> GOCACHE/GOMODCACHE를 setup-build-cache 출력값 사용으로 변경 (runner.temp 폴백 유지)</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/idle-outpost/pull/257/files#diff-e594d8670707ce5ac3fa2b465eed7ddf1c669ba5d731b72d369d7166ffcb7d28">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

